### PR TITLE
Typo fixes

### DIFF
--- a/dyes/Alexa-488.csv
+++ b/dyes/Alexa-488.csv
@@ -1,6 +1,6 @@
 Type: dye
 Name: Alexa-488
-Exctinction coefficient: 73000
+Extinction coefficient: 73000
 Quantum Yield: 0.92
 wavelength,excitation,emission
 251,0.940729976,0

--- a/spectral-transmission.js
+++ b/spectral-transmission.js
@@ -25,7 +25,7 @@ FLOATMATCH = /([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)/
 // match a quantum yield entry
 QYIELDMATCH = /[Qq]uantum [Yy]ield:\s*([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)/
 // match an exctinction coefficient entry
-EXTCOEFFMATCH = /[Ex]tinction [Cc]oefficient:\s*([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)/
+EXTCOEFFMATCH = /[Ee]xtinction [Cc]oefficient:\s*([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)/
 // Alexa-488 birghtness for relative brightness calculations
 var ALEXABRIGHT= 0.92*73000    
 // The set of active filters.


### PR DESCRIPTION
Both the regexp reading and the Alexa-488 definition of Extinction Coefficient had different typos in them. Now fixed so brightness works.
